### PR TITLE
Install java 25 with sdkman

### DIFF
--- a/churrera-cli/src/test/java/info/jab/churrera/cli/ChurreraCLITest.java
+++ b/churrera-cli/src/test/java/info/jab/churrera/cli/ChurreraCLITest.java
@@ -42,7 +42,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;


### PR DESCRIPTION
Remove unused import `org.mockito.Mockito.atLeast` to fix Sonar issue `java:S1128`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e712b408-2a74-4ca0-aa80-0f82ec2dc342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e712b408-2a74-4ca0-aa80-0f82ec2dc342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

